### PR TITLE
Add fill in the blank capability for specific question.

### DIFF
--- a/dialogflowEntitiesJson/CRISPR.json
+++ b/dialogflowEntitiesJson/CRISPR.json
@@ -1,0 +1,16 @@
+{
+  "id": "1b9c4e7b-90ba-4fba-968f-f1a5e0c0a613",
+  "name": "CRISPR",
+  "isOverridable": true,
+  "entries": [
+    {
+      "value": "CRISPR",
+      "synonyms": [
+        "CRISPR",
+        "crispr"
+      ]
+    }
+  ],
+  "isEnum": false,
+  "automatedExpansion": false
+}

--- a/dialogflowIntentsJson/Arts-Science Round - CRISPRQuestion.json
+++ b/dialogflowIntentsJson/Arts-Science Round - CRISPRQuestion.json
@@ -1,0 +1,116 @@
+{
+  "id": "4b30d2bb-0f37-4235-a1e0-bd334cc414ea",
+  "parentId": "b88efddf-92aa-41d4-91d5-71610b513496",
+  "rootParentId": "b88efddf-92aa-41d4-91d5-71610b513496",
+  "name": "Arts-Science Round - CRISPRQuestion",
+  "auto": true,
+  "contexts": [
+    "Arts-ScienceRound-followup"
+  ],
+  "responses": [
+    {
+      "resetContexts": false,
+      "action": "Arts-ScienceRound.Arts-ScienceRound-custom",
+      "affectedContexts": [],
+      "parameters": [
+        {
+          "id": "c0c13a86-b2eb-4a00-9561-635e33692b9e",
+          "required": true,
+          "dataType": "@CRISPR",
+          "name": "crispr",
+          "value": "$crispr",
+          "isList": false
+        }
+      ],
+      "messages": [
+        {
+          "type": 0,
+          "speech": []
+        }
+      ],
+      "defaultResponsePlatforms": {},
+      "speech": []
+    }
+  ],
+  "priority": 500000,
+  "webhookUsed": true,
+  "webhookForSlotFilling": false,
+  "lastUpdate": 1543955276,
+  "fallbackIntent": false,
+  "events": [],
+  "userSays": [
+    {
+      "id": "7401773f-7757-4036-a7da-ede72486ef16",
+      "data": [
+        {
+          "text": "the answer is "
+        },
+        {
+          "text": "crispr",
+          "alias": "crispr",
+          "meta": "@CRISPR",
+          "userDefined": false
+        }
+      ],
+      "isTemplate": false,
+      "count": 0,
+      "updated": 1543955276,
+      "isAuto": false
+    },
+    {
+      "id": "af42b03c-c482-427e-a3c1-942c1ec67071",
+      "data": [
+        {
+          "text": "Wasn't it "
+        },
+        {
+          "text": "crispr",
+          "alias": "crispr",
+          "meta": "@CRISPR",
+          "userDefined": false
+        }
+      ],
+      "isTemplate": false,
+      "count": 0,
+      "updated": 1543955276,
+      "isAuto": false
+    },
+    {
+      "id": "3314e339-a361-4e9c-8f7a-16e34c304939",
+      "data": [
+        {
+          "text": "It's "
+        },
+        {
+          "text": "crispr",
+          "alias": "crispr",
+          "meta": "@CRISPR",
+          "userDefined": false
+        }
+      ],
+      "isTemplate": false,
+      "count": 0,
+      "updated": 1543955276,
+      "isAuto": false
+    },
+    {
+      "id": "0ec7abbf-fe62-4ad5-bd6b-8a6767fe4cce",
+      "data": [
+        {
+          "text": "CRISPR",
+          "alias": "crispr",
+          "meta": "@CRISPR",
+          "userDefined": false
+        }
+      ],
+      "isTemplate": false,
+      "count": 2,
+      "updated": 1543955276,
+      "isAuto": false
+    }
+  ],
+  "followUpIntents": [],
+  "liveAgentHandoff": false,
+  "endInteraction": false,
+  "templates": []
+}

--- a/dialogflowIntentsJson/Arts-Science Round - fallback.json
+++ b/dialogflowIntentsJson/Arts-Science Round - fallback.json
@@ -1,0 +1,37 @@
+{
+  "id": "051835f8-8bfb-4725-a6bf-35d39caff83b",
+  "parentId": "b88efddf-92aa-41d4-91d5-71610b513496",
+  "rootParentId": "b88efddf-92aa-41d4-91d5-71610b513496",
+  "name": "Arts-Science Round - fallback",
+  "auto": false,
+  "contexts": [
+    "Arts-ScienceRound-followup"
+  ],
+  "responses": [
+    {
+      "resetContexts": false,
+      "action": "Arts-ScienceRound.Arts-ScienceRound-fallback",
+      "affectedContexts": [],
+      "parameters": [],
+      "messages": [
+        {
+          "type": 0,
+          "speech": []
+        }
+      ],
+      "defaultResponsePlatforms": {},
+      "speech": []
+    }
+  ],
+  "priority": 500000,
+  "webhookUsed": true,
+  "webhookForSlotFilling": false,
+  "lastUpdate": 1543942055,
+  "fallbackIntent": true,
+  "events": [],
+  "userSays": [],
+  "followUpIntents": [],
+  "liveAgentHandoff": false,
+  "endInteraction": false,
+  "templates": []
+}

--- a/functions/src/content/artsCategoryContent.ts
+++ b/functions/src/content/artsCategoryContent.ts
@@ -1,4 +1,5 @@
 import {
+  FillInTheBlankQuestion,
   MultipleChoiceQuestion,
   Question,
   TrueFalseQuestion,
@@ -7,9 +8,9 @@ import {
 import { Category } from '../models/categories';
 
 const artsQuestions: Question[] = [
-  new TrueFalseQuestion(
+  new FillInTheBlankQuestion(
     'https://s3.eu-west-2.amazonaws.com/year-in-focus-audio/techOpener.mp3',
-    false,
+    'false',
     'https://s3.eu-west-2.amazonaws.com/year-in-focus-audio/techQ1Correct.mp3',
     'https://s3.eu-west-2.amazonaws.com/year-in-focus-audio/techQ1Incorrect.mp3'
   ),

--- a/functions/src/content/scienceCategoryContent.ts
+++ b/functions/src/content/scienceCategoryContent.ts
@@ -18,7 +18,9 @@ const scienceQuestions: Question[] = [
   ),
   new FillInTheBlankQuestion(
     'https://s3.eu-west-2.amazonaws.com/year-in-focus-audio/techQ2.mp3',
-    'true'
+    'CRISPR',
+    'https://s3.eu-west-2.amazonaws.com/year-in-focus-audio/techQ2Correct.mp3',
+    'https://s3.eu-west-2.amazonaws.com/year-in-focus-audio/techQ2Incorrect.mp3'
   ),
   new TrueFalseQuestion(
     'https://s3.eu-west-2.amazonaws.com/year-in-focus-audio/techQ2.mp3',

--- a/functions/src/fulfillments/__tests__/questionFulfillment.test.ts
+++ b/functions/src/fulfillments/__tests__/questionFulfillment.test.ts
@@ -9,23 +9,155 @@ import {
   TrueFalseQuestion,
 } from '../../models/questions';
 import {
+  buildFillInTheBlankQuestionResponse,
+  buildMultipleChoiceQuestionResponse,
+  buildTrueFalseQuestionResponse,
+} from '../../responses/questionResponses';
+import {
   fillInTheBlankHelp,
   multipleChoiceHelp,
   trueFalseHelp,
 } from '../../content/genericQuestionContent';
 import {
+  fillInTheBlankIncorrectFulfillment,
+  fillInTheBlankQuestionFulfillment,
   getQuestionBasedOnConversationData,
   getQuestionSpecificHelpAudio,
-  questionFulfillment,
+  incrementQuestionNumber,
+  multipleChoiceQuestionFulfillment,
   questionHelpFulfillment,
   questionRepromptFulfillment,
+  trueFalseQuestionFulfillment,
 } from '../questionFulfillment';
 
 import { Topic } from '../../models/rounds';
 import { buildSSMLAndCombineAudioResponses } from '../../responses/ssmlResponses';
+import { fallbackFulfillment } from '../helperFulfillments';
 import { unexpectedErrorResponse } from '../../utils/logger';
 
-describe('Question Fulfillment', () => {
+describe('True False Fulfillment', () => {
+  test('If answer cannot be converted to true or false use fallback response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    const answer = 'grapes';
+    trueFalseQuestionFulfillment(answer, data);
+    expect(fallbackFulfillment).toBeCalled;
+  });
+
+  test('If answer can be converted to true build response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    const answer = 'true';
+    trueFalseQuestionFulfillment(answer, data);
+    expect(buildTrueFalseQuestionResponse).toBeCalled;
+  });
+
+  test('If answer can be converted to false build response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    const answer = 'false';
+    trueFalseQuestionFulfillment(answer, data);
+    expect(buildTrueFalseQuestionResponse).toBeCalled;
+  });
+});
+
+describe('Fill in the blank Fulfillment', () => {
+  test('If question could not be retrieved expect error response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+    };
+    fillInTheBlankQuestionFulfillment('', data);
+    expect(fallbackFulfillment).toBeCalled;
+  });
+
+  test('If question can be retrieved build response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    fillInTheBlankQuestionFulfillment('', data);
+    expect(buildFillInTheBlankQuestionResponse).toBeCalled;
+  });
+});
+
+describe('Fill in the blank incorrect answer Fulfillment', () => {
+  test('If question could not be retrieved expect error response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+    };
+    fillInTheBlankIncorrectFulfillment(data);
+    expect(fallbackFulfillment).toBeCalled;
+  });
+
+  test('If question can be retrieved build response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    fillInTheBlankIncorrectFulfillment(data);
+    expect(fillInTheBlankIncorrectFulfillment).toBeCalled;
+  });
+});
+
+describe('Multiple Choice Fulfillment', () => {
+  test('If answer cannot be converted to A,B,C or D use fallback response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    const answer = 'grapes';
+    multipleChoiceQuestionFulfillment(answer, data);
+    expect(fallbackFulfillment).toBeCalled;
+  });
+
+  test('If answer can be converted to A build response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    const answer = 'A';
+    multipleChoiceQuestionFulfillment(answer, data);
+    expect(buildMultipleChoiceQuestionResponse).toBeCalled;
+  });
+
+  test('If answer can be converted to B build response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    const answer = 'B';
+    multipleChoiceQuestionFulfillment(answer, data);
+    expect(buildMultipleChoiceQuestionResponse).toBeCalled;
+  });
+
+  test('If answer can be converted to C build response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    const answer = 'C';
+    multipleChoiceQuestionFulfillment(answer, data);
+    expect(buildMultipleChoiceQuestionResponse).toBeCalled;
+  });
+
+  test('If answer can be converted to D build response', () => {
+    const data: ConversationData = {
+      startRepromptIssued: false,
+      currentTopic: Topic.NEWS,
+    };
+    const answer = 'D';
+    multipleChoiceQuestionFulfillment(answer, data);
+    expect(buildMultipleChoiceQuestionResponse).toBeCalled;
+  });
+});
+
+describe('Increment Question Number', () => {
   test('If question number is undefined next question number should be 1 as you must currently be asking question 1', () => {
     const data: ConversationData = {
       startRepromptIssued: false,
@@ -36,7 +168,7 @@ describe('Question Fulfillment', () => {
       currentQuestion: 1,
       currentTopic: Topic.NEWS,
     };
-    questionFulfillment('', data);
+    incrementQuestionNumber(data);
     expect(data).toEqual(expectedData);
   });
 
@@ -51,7 +183,7 @@ describe('Question Fulfillment', () => {
       currentQuestion: 2,
       currentTopic: Topic.NEWS,
     };
-    questionFulfillment('', data);
+    incrementQuestionNumber(data);
     expect(data).toEqual(expectedData);
   });
 });
@@ -111,7 +243,7 @@ describe('questionHelpFulfillment', () => {
 
 describe('getQuestionSpecificHelpAudio', () => {
   test('True false question gets true false audio', () => {
-    const question = new TrueFalseQuestion('', '', '', '');
+    const question = new TrueFalseQuestion('', true, '', '');
     const response = getQuestionSpecificHelpAudio(question);
     expect(response).toEqual(trueFalseHelp);
   });
@@ -123,7 +255,7 @@ describe('getQuestionSpecificHelpAudio', () => {
   });
 
   test('fill in the blank question gets fill in the blank audio', () => {
-    const question = new FillInTheBlankQuestion('', '');
+    const question = new FillInTheBlankQuestion('', '', '', '');
     const response = getQuestionSpecificHelpAudio(question);
     expect(response).toEqual(fillInTheBlankHelp);
   });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,6 +14,12 @@ import {
   repeatFulfillment,
 } from './fulfillments/helperFulfillments';
 import {
+  fillInTheBlankIncorrectFulfillment,
+  fillInTheBlankQuestionFulfillment,
+  multipleChoiceQuestionFulfillment,
+  trueFalseQuestionFulfillment,
+} from './fulfillments/questionFulfillment';
+import {
   respondBasedOnResponseType,
   respondToUserInput,
 } from './responses/dialogflowResponses';
@@ -21,7 +27,6 @@ import {
 import { ConversationData } from './models/conversation';
 import { convertSSMLContainerToString } from './responses/ssmlResponses';
 import { dialogflow } from 'actions-on-google';
-import { questionFulfillment } from './fulfillments/questionFulfillment';
 import { startCategory } from './fulfillments/categoryFulfillment';
 
 const app = dialogflow<ConversationData, {}>({
@@ -89,14 +94,14 @@ app.intent<{ topicChoice: string }>(
 app.intent<{ answer: string }>(
   'News-Sport Round - trueFalse',
   (conv, { answer }) => {
-    respondToUserInput(answer, conv, questionFulfillment);
+    respondToUserInput(answer, conv, trueFalseQuestionFulfillment);
   }
 );
 
 app.intent<{ answer: string }>(
   'News-Sport Round - multipleChoice',
   (conv, { answer }) => {
-    respondToUserInput(answer, conv, questionFulfillment);
+    respondToUserInput(answer, conv, multipleChoiceQuestionFulfillment);
   }
 );
 
@@ -110,16 +115,27 @@ app.intent<{ topicChoice: string }>(
 app.intent<{ answer: string }>(
   'Arts-Science Round - trueFalse',
   (conv, { answer }) => {
-    respondToUserInput(answer, conv, questionFulfillment);
+    respondToUserInput(answer, conv, trueFalseQuestionFulfillment);
   }
 );
 
 app.intent<{ answer: string }>(
   'Arts-Science Round - multipleChoice',
   (conv, { answer }) => {
-    respondToUserInput(answer, conv, questionFulfillment);
+    respondToUserInput(answer, conv, multipleChoiceQuestionFulfillment);
   }
 );
+
+app.intent<{ crispr: string }>(
+  'Arts-Science Round - CRISPRQuestion',
+  (conv, { crispr }) => {
+    respondToUserInput(crispr, conv, fillInTheBlankQuestionFulfillment);
+  }
+);
+
+app.intent('Arts-Science Round - fallback', conv => {
+  respondBasedOnResponseType(fillInTheBlankIncorrectFulfillment, conv);
+});
 
 app.intent('Quit App', conv => {
   const response = convertSSMLContainerToString(doNotPlayFulfillment());

--- a/functions/src/models/conversation.ts
+++ b/functions/src/models/conversation.ts
@@ -26,4 +26,13 @@ class Response {
 
 type OptionString = string | Unknown;
 
-export { ConversationData, Unknown, Response, ResponseType, OptionString };
+type OptionBoolean = boolean | unknown;
+
+export {
+  ConversationData,
+  Unknown,
+  Response,
+  ResponseType,
+  OptionString,
+  OptionBoolean,
+};

--- a/functions/src/models/questions.ts
+++ b/functions/src/models/questions.ts
@@ -29,25 +29,33 @@ class MultipleChoiceQuestion extends Question {
 }
 
 class FillInTheBlankQuestion extends Question {
-  constructor(questionAudio: string, public answer: string) {
+  constructor(
+    questionAudio: string,
+    public answer: string,
+    public correctAnswerAudio: string,
+    public incorrectAnswerAudio: string
+  ) {
     super(questionAudio);
   }
 }
 
 type OptionQuestion = Question | Unknown;
 
-enum MultipleChoiceOption {
+enum MultipleChoice {
   A = 'A',
   B = 'B',
   C = 'C',
   D = 'D',
 }
 
+type OptionMultipleChoice = MultipleChoice | Unknown;
+
 export {
   Question,
   OptionQuestion,
-  MultipleChoiceOption,
+  MultipleChoice,
   TrueFalseQuestion,
   MultipleChoiceQuestion,
   FillInTheBlankQuestion,
+  OptionMultipleChoice,
 };


### PR DESCRIPTION
Make the fulfillments for different questions more specific so there is one for each question type. This gives more type safety on the answers but adds in some code duplication.
User is reprompted if they respond incorrectly to a question type e.g. you cannot respond 'true' to a multiple choice question
Add the ability to ask an open ended question. In this case where the answer is going to be 'CRISPR'

Still using dummy audio.